### PR TITLE
Correctly return JSON when we're expecting to

### DIFF
--- a/src/http/get-micropub/index.js
+++ b/src/http/get-micropub/index.js
@@ -16,6 +16,7 @@ async function getPost (params, scopes) {
         error: 'not_found',
         error_description: 'Post was not found'
       }),
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
       statusCode: 404
     }
   }
@@ -28,6 +29,7 @@ async function getPost (params, scopes) {
         type: 'entry',
         properties: { deleted: post.properties.deleted[0] }
       }),
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
       statusCode: 410
     }
   }
@@ -66,6 +68,7 @@ async function source (params, scopes) {
         error: 'invalid_parameter',
         error_description: 'URL parameter is invalid'
       }),
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
       statusCode: 400
     }
   }

--- a/src/http/post-micropub/micropub/create.js
+++ b/src/http/post-micropub/micropub/create.js
@@ -97,7 +97,8 @@ async function create (scope, body) {
       body: JSON.stringify({
         error: 'invalid_parameter',
         error_description: 'A post with this URL already exists'
-      })
+      }),
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
     }
   }
 

--- a/src/http/post-micropub/micropub/update.js
+++ b/src/http/post-micropub/micropub/update.js
@@ -64,7 +64,8 @@ async function update (properties) {
       body: JSON.stringify({
         error: 'invalid_request',
         error_description: e.message
-      })
+      }),
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
     }
   }
 

--- a/src/http/post-webmention/index.js
+++ b/src/http/post-webmention/index.js
@@ -14,6 +14,7 @@ exports.handler = async function http (req) {
         error: 'unauthorized',
         error_description: 'Secret does not match.'
       }),
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
       statusCode: 403
     }
   }

--- a/src/shared/auth.js
+++ b/src/shared/auth.js
@@ -19,6 +19,7 @@ async function requireScopes (scopes, headers, body) {
         error: 'unauthorized',
         error_description: 'Request is missing an access token.'
       }),
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
       statusCode: 401
     }
   }
@@ -57,6 +58,7 @@ const verifyTokenAndScopes = async function (token, scopes) {
           error_description: 'The authenticated user does not have permission' +
             ' to perform this request.'
         }),
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
         statusCode: 401
       }
     }
@@ -70,6 +72,7 @@ const verifyTokenAndScopes = async function (token, scopes) {
       return {
         statusCode: 200,
         body: JSON.stringify({ message: 'Scope was authorised.' }),
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
         scopes: tokenScopes
       }
     }
@@ -80,6 +83,7 @@ const verifyTokenAndScopes = async function (token, scopes) {
       error_description: 'The user does not have sufficient scope to perform' +
         ' this action.'
     }),
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
     statusCode: 401
   }
 }


### PR DESCRIPTION
As noticed in #7, there are a few places that we return JSON bodies, but
don't specify the `content-type`, therefore default to returning plain
text responses.

Closes #7.
