### PR TITLE
Return `q=post-types`

### DIFF
--- a/src/http/get-micropub/config/index.js
+++ b/src/http/get-micropub/config/index.js
@@ -33,6 +33,7 @@ const config = {
 module.exports = {
   q,
   config,
+  postTypes,
   syndicateTo,
   category,
   channels

--- a/src/http/get-micropub/index.js
+++ b/src/http/get-micropub/index.js
@@ -96,6 +96,8 @@ exports.handler = async function http (req) {
         return { channels: config.channels }
       case 'source':
         return await source(params, authResponse.scopes)
+      case 'post-types':
+        return await { 'post-types': config.postTypes }
     }
   }
   return {

--- a/test/get-micropub-test.js
+++ b/test/get-micropub-test.js
@@ -73,6 +73,15 @@ test('q=syndicate-to returns syndications', async t => {
   t.ok(body['syndicate-to'].length > 0, 'syndicate-to is not empty')
 })
 
+test('q=post-types returns a valid response', async t => {
+  t.plan(3)
+  const response = await fetch(`${micropubUrl}?q=post-types`)
+  const body = await response.json()
+  t.ok(body['post-types'], 'found post-types object')
+  t.ok(Array.isArray(body['post-types']), 'post-types is an array')
+  t.ok(body['post-types'].length > 0, 'post-types is not empty')
+})
+
 test('end', async t => {
   t.plan(1)
   const result = await sandbox.end()


### PR DESCRIPTION
We currently advertise that `q=post-types` is supported as a standalone
query, but it doesn't have any HTTP logic available.

This adds test coverage + implements the logic to support the query.
