### PR TITLE
Add Meetup/Eventbrite context retrieval

### DIFF
--- a/src/events/fetch-context/eventbrite.js
+++ b/src/events/fetch-context/eventbrite.js
@@ -1,0 +1,34 @@
+const fetch = require('node-fetch')
+const logger = require('@architect/shared/logger')
+
+async function isEventbriteUrl (url) {
+  return ((url.indexOf('https://eventbrite.com') > -1) ||
+    (url.indexOf('https://www.eventbrite.com') > -1) ||
+    (url.indexOf('https://eventbrite.co.uk') > -1) ||
+    (url.indexOf('https://www.eventbrite.co.uk') > -1))
+}
+
+async function getEventbriteUrl (url) {
+  const parsed = new URL(url)
+  return 'https://eventbrite-mf2.herokuapp.com' + parsed.pathname
+}
+
+async function fetchContext (url) {
+  if (!isEventbriteUrl(url)) {
+    return
+  }
+  const response = await fetch(getEventbriteUrl(url))
+  if (!response.ok) {
+    const text = await response.text()
+    logger.warn('Failed to fetch context from Eventbrite-MF2', `${url}\n${text}`)
+    return
+  }
+  const mf2 = await response.json()
+  if (!('items' in mf2) || !mf2.items.length) return
+  return mf2.items[0].properties
+}
+
+module.exports = {
+  isEventbriteUrl,
+  fetchContext
+}

--- a/src/events/fetch-context/index.js
+++ b/src/events/fetch-context/index.js
@@ -1,16 +1,30 @@
 const arc = require('@architect/functions')
 const logger = require('@architect/shared/logger')
+const eventbrite = require('./eventbrite')
 const granary = require('./granary')
+const meetup = require('./meetup')
 const openGraph = require('./open-graph')
 
 async function getContext (url) {
-  // try granary and then use opengraph
+  // for specific sites, use custom parsing
+  if (meetup.isMeetupUrl(url)) {
+    const properties = await meetup.fetchContext(url)
+    if (properties) {
+      return properties
+    }
+  } else if (eventbrite.isEventbriteUrl(url)) {
+    const properties = await eventbrite.fetchContext(url)
+    if (properties) {
+      return properties
+    }
+  }
+  // otherwise fallback to Granary, and then OpenGraph
   const properties = await granary.fetchContext(url)
   if (properties) {
     return properties
-  } else {
-    return await openGraph.fetchContext(url)
   }
+
+  return await openGraph.fetchContext(url)
 }
 
 exports.handler = async function subscribe (event) {

--- a/src/events/fetch-context/meetup.js
+++ b/src/events/fetch-context/meetup.js
@@ -1,0 +1,32 @@
+const fetch = require('node-fetch')
+const logger = require('@architect/shared/logger')
+
+async function isMeetupUrl (url) {
+  return ((url.indexOf('https://meetup.com') > -1) ||
+    (url.indexOf('https://www.meetup.com') > -1))
+}
+
+function getMeetupUrl (url) {
+  const parsed = new URL(url)
+  return 'https://meetup-mf2.herokuapp.com' + parsed.pathname
+}
+
+async function fetchContext (url) {
+  if (!isMeetupUrl(url)) {
+    return
+  }
+  const response = await fetch(getMeetupUrl(url))
+  if (!response.ok) {
+    const text = await response.text()
+    logger.warn('Failed to fetch context from Meetup-MF2', `${url}\n${text}`)
+    return
+  }
+  const mf2 = await response.json()
+  if (!('items' in mf2) || !mf2.items.length) return
+  return mf2.items[0].properties
+}
+
+module.exports = {
+  isMeetupUrl,
+  fetchContext
+}


### PR DESCRIPTION
As I RSVP to events on Meetup/Eventbrite, it'd be useful to have the
Pipes that I've set up for retrieving metadata from them to be supported
in `fetch-context`.

These follow the format of Granary, but expose an `is..Url` helper so we
can simplify the logic when retrieving context.

Additionally, we only want to use them if properties are found for a
lookup, otherwise still fall back to Granary/OpenGraph.
