### PR TITLE
Log to console when running locally

### DIFF
--- a/src/shared/logger.js
+++ b/src/shared/logger.js
@@ -14,6 +14,9 @@ async function log (type, message, description) {
     description,
     expires
   }
+  if (process.env.ARC_ROLE && process.env.ARC_ROLE === 'SandboxRole') {
+    console.log(JSON.stringify(log))
+  }
   await data.logs.put(log)
 }
 


### PR DESCRIPTION
As well as using the `/logs` page, having output on the console output
can be convenient, too.

This only applies to locally executing Arc Sandbox.
