### PR TITLE
Use ARM infrastructure

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -3,6 +3,7 @@ vibrancy
 
 @aws
 region eu-west-2
+architecture arm64
 
 @http
 get /


### PR DESCRIPTION
Node works nicely on ARM, and as it generally leads to better
performance for reduced cost, we should move our underlying Lambda
infrastructure over to it.
