### PR TITLE
Allow `npm run test` to work in isolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,6 @@ jobs:
       run: npm run lint
 
     - name: Run tests
-      env:
-        ROOT_URL: http://localhost:4444/
-        MEDIA_ENDPOINT_URL: http://localhost:3334/
       run: npm test
 
     - name: Deploy

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,4 @@ jobs:
       run: npm run lint
 
     - name: Run tests
-      env:
-        MEDIA_ENDPOINT_URL: http://localhost:3334/
-        ROOT_URL: http://localhost:4444/
       run: npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Personal website Micropub server",
   "scripts": {
     "start": "PORT=3333 arc sandbox",
-    "test": "NODE_ENV=testing PORT=3334 tape test/*-test.js",
+    "test": "NODE_ENV=testing PORT=3334 MEDIA_ENDPOINT_URL=http://localhost:3334/ ROOT_URL=http://localhost:4444/ tape test/*-test.js",
     "lint": "standard"
   },
   "dependencies": {


### PR DESCRIPTION
Instead of using the environment variables setup within the GitHub
Actions workflow, we should ensure that all tests pass through `npm run
test`, so it's an easier and more consistent local feedback loop.
