### PR TITLE
Gitignore `prefs.arc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ sam.yaml
 
 .bundle
 vendor
+prefs.arc


### PR DESCRIPTION
As it includes secrets, therefore we should make it very difficult for
folks to accidentally commit it.
